### PR TITLE
fix:update Dockerfile with config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL maintainer="Moov <oss@moov.io>"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/moov-io/fincen/bin/server /bin/server
+COPY --from=builder /go/src/github.com/moov-io/fincen/configs/config.default.yml /configs/config.default.yml
 COPY --from=builder /etc/passwd /etc/passwd
 
 USER moov


### PR DESCRIPTION
Hi Moov friends, while looking at this project I realized that the docker container will build but not run due to the default config file missing. Thought I would send this fix up to unblock others who might be building/running it.

Changes: added a copy for the config file to the expected `/config` location

