### PR TITLE
feat: fixing fc to fc2 for formTypeCode and adding empty indicator fo…

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -194,7 +194,7 @@ type EFilingBatchMarshal struct {
 	NoFIOwnerCount          int64                 `xml:"NoFIOwnerCount,attr,omitempty" json:",omitempty"`
 	ConsolidatedOwnerCount  int64                 `xml:"ConsolidatedOwnerCount,attr,omitempty" json:",omitempty"`
 	Attrs                   []xml.Attr            `xml:",any,attr"`
-	FormTypeCode            string                `xml:"fc:FormTypeCode,omitempty" json:",omitempty"`
+	FormTypeCode            string                `xml:"fc2:FormTypeCode,omitempty" json:",omitempty"`
 	ActivitiesContent       []byte                `xml:",innerxml"`
 	EFilingSubmissionXML    *EFilingSubmissionXML `xml:"EFilingSubmissionXML,omitempty" json:",omitempty"`
 }

--- a/primitive.go
+++ b/primitive.go
@@ -354,7 +354,7 @@ type ValidateIndicatorType string
 
 func (r ValidateIndicatorType) Validate() error {
 	for _, vv := range []string{
-		"Y",
+		"Y", "",
 	} {
 		if reflect.DeepEqual(string(r), vv) {
 			return nil


### PR DESCRIPTION
- this addresses two issues:
1. the name space prefix added previously had one small mistake fc instead of fc2 for FormTypeCode
2. ValidateIndicatorType should accept empty and in the two issues I raised according to the user guide.  