### PR TITLE
fix: fincen requies a 2 (ein) for 30 and 34 which is reporting financ…

### DIFF
--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -248,7 +248,7 @@ func (r PartyType) fieldInclusion() error {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed["4"] {
+		if !existed["2"] {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case "8":
@@ -269,7 +269,7 @@ func (r PartyType) fieldInclusion() error {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed["4"] {
+		if !existed["2"] {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case "33":


### PR DESCRIPTION
According to the SAR XML User Guide, both 30/34 require 2 (ein) instead of 4(tin) 

Attaching screenshots to demonstrate this:

<img width="977" alt="Screen Shot 2022-11-14 at 10 35 48 AM" src="https://user-images.githubusercontent.com/16566431/201702942-4ec030f7-158e-4542-888e-893a9336913b.png">
