### PR TITLE
fix: fincen needs the order of party account association to have part…

### DIFF
--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -569,9 +569,9 @@ func (r AssociationParty) Validate(args ...string) error {
 type PartyAccountAssociationType struct {
 	XMLName                         xml.Name                                `xml:"PartyAccountAssociation"`
 	SeqNum                          fincen.SeqNumber                        `xml:"SeqNum,attr"`
+	PartyAccountAssociationTypeCode ValidatePartyAccountAssociationCodeType `xml:"PartyAccountAssociationTypeCode"`
 	Party                           []*AccountAssociationParty              `xml:"Party"`
 	AccountClosedIndicator          *fincen.ValidateIndicatorNullType       `xml:"AccountClosedIndicator,omitempty" json:",omitempty"`
-	PartyAccountAssociationTypeCode ValidatePartyAccountAssociationCodeType `xml:"PartyAccountAssociationTypeCode"`
 }
 
 func (r PartyAccountAssociationType) fieldInclusion(typeCode string) error {

--- a/pkg/suspicious_activity/activity_test.go
+++ b/pkg/suspicious_activity/activity_test.go
@@ -200,15 +200,15 @@ func mocParties() map[string][]byte {
 	<Account SeqNum="77">
 		<AccountNumberText>1502417873</AccountNumberText>
 		<PartyAccountAssociation SeqNum="78">
-			<AccountClosedIndicator>Y</AccountClosedIndicator>
 			<PartyAccountAssociationTypeCode>5</PartyAccountAssociationTypeCode>
+			<AccountClosedIndicator>Y</AccountClosedIndicator>
 		</PartyAccountAssociation>
 	</Account>
 	<Account SeqNum="79">
 		<AccountNumberText>5477887896</AccountNumberText>
 		<PartyAccountAssociation SeqNum="80">
-			<AccountClosedIndicator>Y</AccountClosedIndicator>
 			<PartyAccountAssociationTypeCode>5</PartyAccountAssociationTypeCode>
+			<AccountClosedIndicator>Y</AccountClosedIndicator>
 		</PartyAccountAssociation>
 	</Account>
 </Party>`)
@@ -276,10 +276,10 @@ func mocParties() map[string][]byte {
 		<SubjectRelationshipFinancialInstitutionTINText>458789856</SubjectRelationshipFinancialInstitutionTINText>
 	</PartyAssociation>
 	<PartyAccountAssociation SeqNum="74">
+		<PartyAccountAssociationTypeCode>7</PartyAccountAssociationTypeCode>
 		<Party SeqNum="75">
 			<ActivityPartyTypeCode>41</ActivityPartyTypeCode>
 		</Party>
-		<PartyAccountAssociationTypeCode>7</PartyAccountAssociationTypeCode>
 	</PartyAccountAssociation>
 </Party>`)
 


### PR DESCRIPTION
When we added the PartyAccountAssociationType to Subject, fincen is rejecting the XML saying that party account association type code is in the wrong position.  

According to the FINCENSAR user guide sample -> this element should be ahead of the Party

<img width="1834" alt="Screen Shot 2022-11-23 at 10 57 07 AM" src="https://user-images.githubusercontent.com/16566431/203591750-fca0d725-fc19-4b44-81c1-96b5fd9436e1.png">
