### PR TITLE
fix: failing fincen integration with AssetsTable, should be Assets

### DIFF
--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -45,7 +45,7 @@ type ActivityType struct {
 	SuspiciousActivity            *SuspiciousActivityType             `xml:"SuspiciousActivity"`
 	ActivityIPAddress             []*ActivityIPAddressType            `xml:"ActivityIPAddress,omitempty" json:",omitempty"`
 	CyberEventIndicators          []*CyberEventIndicatorsType         `xml:"CyberEventIndicators,omitempty" json:",omitempty"`
-	Assets                        []*AssetsTableType                  `xml:"Assets,omitempty" json:",omitempty"`
+	Assets                        []*AssetsType                       `xml:"Assets,omitempty" json:",omitempty"`
 	AssetsAttribute               []*AssetsAttributeType              `xml:"AssetsAttribute,omitempty" json:",omitempty"`
 	ActivityNarrativeInformation  []*ActivityNarrativeInformationType `xml:"ActivityNarrativeInformation"`
 }
@@ -675,15 +675,15 @@ func (r AssetsAttributeType) Validate(args ...string) error {
 	return fincen.Validate(&r, args...)
 }
 
-type AssetsTableType struct {
-	XMLName               xml.Name                              `xml:"AssetsTable"`
+type AssetsType struct {
+	XMLName               xml.Name                              `xml:"Assets"`
 	SeqNum                fincen.SeqNumber                      `xml:"SeqNum,attr"`
 	AssetSubtypeID        fincen.ValidateAssetSubtypeIDTypeCode `xml:"AssetSubtypeID"`
 	AssetTypeID           fincen.ValidateAssetTypeIDTypeCode    `xml:"AssetTypeID"`
 	OtherAssetSubtypeText *fincen.RestrictString50              `xml:"OtherAssetSubtypeText,omitempty" json:",omitempty"`
 }
 
-func (r AssetsTableType) Validate(args ...string) error {
+func (r AssetsType) Validate(args ...string) error {
 	return fincen.Validate(&r, args...)
 }
 

--- a/pkg/suspicious_activity/primitive_test.go
+++ b/pkg/suspicious_activity/primitive_test.go
@@ -25,7 +25,7 @@ var (
 	_ fincen.Element         = (*AssociationParty)(nil)
 	_ fincen.Element         = (*AccountAssociationParty)(nil)
 	_ fincen.Element         = (*AssetsAttributeType)(nil)
-	_ fincen.Element         = (*AssetsTableType)(nil)
+	_ fincen.Element         = (*AssetsType)(nil)
 	_ fincen.Element         = (*CyberEventIndicatorsType)(nil)
 	_ fincen.Element         = (*ElectronicAddressType)(nil)
 	_ fincen.Element         = (*OrganizationClassificationTypeSubtypeType)(nil)


### PR DESCRIPTION
There's no AssetsTable in the schema for SAR only Assets, attaching screenshot of the fincen rejection

<img width="895" alt="Screen Shot 2022-12-08 at 6 49 33 PM" src="https://user-images.githubusercontent.com/16566431/206590749-95ef3ca6-12c1-4c3d-b230-809f9ce771ae.png">
<img width="895" alt="Screen Shot 2022-12-08 at 6 50 32 PM" src="https://user-images.githubusercontent.com/16566431/206590796-e0573df1-ab93-49e7-a1ae-4deea4ceb975.png">
