### PR TITLE
fix: batch isn't attaching activites together

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -284,7 +284,7 @@ func (r EFilingBatchXML) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 		// force namespace prefix
 		start.Name.Local = "fc2:EFilingBatchXML"
 	}
-	
+
 	content := []byte{'\n'}
 	for _, act := range r.Activity {
 		if converted, err := fincen.MarshalIndent(act, fincen.DefaultXMLIntent, fincen.DefaultXMLIntent); err == nil {

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -284,9 +284,9 @@ func (r EFilingBatchXML) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 		// force namespace prefix
 		start.Name.Local = "fc2:EFilingBatchXML"
 	}
-
+	
+	content := []byte{'\n'}
 	for _, act := range r.Activity {
-		content := []byte{'\n'}
 		if converted, err := fincen.MarshalIndent(act, fincen.DefaultXMLIntent, fincen.DefaultXMLIntent); err == nil {
 			content = append(content, converted...)
 		}


### PR DESCRIPTION
When I tried to use the MarshalXML such as and I have multiple activities, the last activity in will overwrite the previous one.  This fix will allow all the activites to keep attaching for batch XML. 

```
name := xml.Name{Local: "EFilingBatchXML"}
	start := xml.StartElement{Name: name}
	err = fincenReport.MarshalXML(xml.NewEncoder(sarWriter), start)
	if err != nil {
		return file, err
	}
```