### PR TITLE
fix: need to add in cash out codes for currency transaction activity …

### DIFF
--- a/pkg/currency_transaction/primitive.go
+++ b/pkg/currency_transaction/primitive.go
@@ -81,7 +81,8 @@ func (r ValidatePartyAccountAssociationCodeType) Validate() error {
 }
 
 // May be one of "55", "46", "23", "12", "14", "49", "18", "21", "25", "997", "53", for cash in
-//  "56", "30", "32", "13", "15", "48", "28", "31", "33", "34", "998", "54", for cash out
+//
+//	"56", "30", "32", "13", "15", "48", "28", "31", "33", "34", "998", "54", for cash out
 type ValidateCurrencyTransactionActivityDetailCodeType string
 
 func (r ValidateCurrencyTransactionActivityDetailCodeType) Validate() error {

--- a/pkg/currency_transaction/primitive.go
+++ b/pkg/currency_transaction/primitive.go
@@ -80,12 +80,14 @@ func (r ValidatePartyAccountAssociationCodeType) Validate() error {
 	return fincen.NewErrValueInvalid("PartyAccountAssociationCode")
 }
 
-// May be one of "55", "46", "23", "12", "14", "49", "18", "21", "25", "997", "53",
+// May be one of "55", "46", "23", "12", "14", "49", "18", "21", "25", "997", "53", for cash in
+//  "56", "30", "32", "13", "15", "48", "28", "31", "33", "34", "998", "54", for cash out
 type ValidateCurrencyTransactionActivityDetailCodeType string
 
 func (r ValidateCurrencyTransactionActivityDetailCodeType) Validate() error {
 	for _, vv := range []string{
 		"55", "46", "23", "12", "14", "49", "18", "21", "25", "997", "53",
+		"56", "30", "32", "13", "15", "48", "28", "31", "33", "34", "998", "54",
 	} {
 		if reflect.DeepEqual(string(r), vv) {
 			return nil


### PR DESCRIPTION
Cash out codes are missing for currency transaction activity detail type 

<img width="1039" alt="Screenshot 2024-01-04 at 5 08 49 PM" src="https://github.com/moov-io/fincen/assets/16566431/2552b223-c0a8-43c1-bb28-e827699f07da">
