### PR TITLE
fix: float64 with 7 digits are printing out with scientific notation

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -184,7 +184,7 @@ type EFilingBatchMarshal struct {
 	XMLName                 xml.Name              `xml:"EFilingBatchXML"`
 	SeqNum                  fincen.SeqNumber      `xml:"SeqNum,attr,omitempty" json:",omitempty"`
 	StatusCode              string                `xml:"StatusCode,attr,omitempty" json:",omitempty"`
-	TotalAmount             float64               `xml:"TotalAmount,attr,omitempty" json:",omitempty"`
+	TotalAmount             prettyFloat           `xml:"TotalAmount,attr" json:",omitempty"`
 	PartyCount              int64                 `xml:"PartyCount,attr,omitempty" json:",omitempty"`
 	ActivityCount           int64                 `xml:"ActivityCount,attr,omitempty" json:",omitempty"`
 	AccountCount            int64                 `xml:"AccountCount,attr,omitempty" json:",omitempty"`
@@ -199,13 +199,20 @@ type EFilingBatchMarshal struct {
 	EFilingSubmissionXML    *EFilingSubmissionXML `xml:"EFilingSubmissionXML,omitempty" json:",omitempty"`
 }
 
+type prettyFloat float64
+
+func (f prettyFloat) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	s := fmt.Sprintf("%.0f", f)
+	return xml.Attr{Name: name, Value: s}, nil
+}
+
 func (r EFilingBatchXML) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 	dummy := EFilingBatchMarshal{
 		XMLName:                 r.XMLName,
 		SeqNum:                  r.SeqNum,
 		StatusCode:              r.StatusCode,
-		TotalAmount:             r.TotalAmount,
+		TotalAmount:             prettyFloat(r.TotalAmount),
 		PartyCount:              r.PartyCount,
 		ActivityCount:           r.ActivityCount,
 		AccountCount:            r.AccountCount,


### PR DESCRIPTION
Two issues that this PR deals with 
1. We had a filing which was $1,252,363.25 and this produced scientific notation looking like 1.252364e+06 which fincen doesn't accept. See image attached and code looking like: <fc2:EFilingBatchXML TotalAmount="1.252364e+06" PartyCount="1"

![image (8)](https://github.com/moov-io/fincen/assets/16566431/6abc1755-101c-4917-8bc7-96ff1ed94643)

After this change it becomes:
<fc2:EFilingBatchXML TotalAmount="1252363" PartyCount="1" ActivityCount="1"

3. For SAR filings with 0 amounts, the total amount field is omitted because it's omit empty, we used to do something hacky in our code which adds this element with 0 value but taking out the omit empty tag will fix this issue as well

Our workaround looked like this:
`if totalAmount == 0 {
		fincenReport.Attrs = append(
			fincenReport.Attrs, xml.Attr{
				Name:  xml.Name{Local: "TotalAmount"},
				Value: "0",
			})
	}`