### PR TITLE
feat: Update PartyIdentification validation to accept EIN, TIN, and FIN codes for Party 30 and 34

### DIFF
--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -386,6 +386,15 @@ func (r EFilingBatchXML) generateAttrs() batchAttr {
 
 	}
 
+	s.ActivityCount = r.ActivityCount
+	s.TotalAmount = r.TotalAmount
+	s.PartyCount = r.PartyCount
+	s.ActivityAttachmentCount = r.ActivityAttachmentCount
+	s.AttachmentCount = r.AttachmentCount
+	s.JointlyOwnedOwnerCount = r.JointlyOwnedOwnerCount
+	s.NoFIOwnerCount = r.NoFIOwnerCount
+	s.ConsolidatedOwnerCount = r.ConsolidatedOwnerCount
+
 	return s
 }
 

--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -286,7 +286,7 @@ if !(existed[PartyITCEIN] || existed[PartyITCTIN] || existed[PartyITCFIN]) {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed[PartyITCEIN] && !existed[PartyITCTIN] && !existed[PartyITCFIN] {
+if !(existed[PartyITCEIN] || existed[PartyITCTIN] || existed[PartyITCFIN]) {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case PartySubject:

--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -265,7 +265,7 @@ func (r PartyType) fieldInclusion() error {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed[PartyITCEIN] && !existed[PartyITCTIN] && !existed[PartyITCFIN] {
+if !(existed[PartyITCEIN] || existed[PartyITCTIN] || existed[PartyITCFIN]) {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case PartyContactOffice:

--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -26,6 +26,7 @@ const (
 	PartyBranch                      = "46"
 	PartyITCTCC                      = "28"
 	PartyITCTIN                      = "4"
+	PartyITCEIN                      = "1"
 	PartyITCFIN                      = "2"
 )
 
@@ -264,7 +265,7 @@ func (r PartyType) fieldInclusion() error {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed[PartyITCFIN] {
+		if !existed[PartyITCEIN] && !existed[PartyITCTIN] && !existed[PartyITCFIN] {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case PartyContactOffice:
@@ -285,7 +286,7 @@ func (r PartyType) fieldInclusion() error {
 		if len(r.PartyIdentification) < 1 || len(r.PartyIdentification) > 3 {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
-		if !existed[PartyITCFIN] {
+		if !existed[PartyITCEIN] && !existed[PartyITCTIN] && !existed[PartyITCFIN] {
 			return fincen.NewErrValueInvalid("PartyIdentification")
 		}
 	case PartySubject:


### PR DESCRIPTION
### FinCEN Documentation Compliance
According to FinCEN documentation, the following party types accept multiple TIN type codes for PartyIdentification:

**Party Type 30 (Filing Institution)** - Accepts TIN types:
- `1` - Employer Identification Number (EIN)
- `2` - Social Security Number (SSN) / Financial Institution Number
- `4` - Tax Identification Number (TIN)
- <img width="627" height="148" alt="image" src="https://github.com/user-attachments/assets/5f122f25-3086-4020-a8f6-52b8d2fbc8c0" />

**Party Type 34 (Financial Institution)** - Accepts TIN types:
- `1` - Employer Identification Number (EIN)
- `2` - Social Security Number (SSN) / Financial Institution Number
- `4` - Tax Identification Number (TIN)
- <img width="627" height="202" alt="image" src="https://github.com/user-attachments/assets/590f4236-fd7f-4027-b7b7-e8417b9be92d" />
## Previous Behavior
The validation was incorrectly restricted to only accept PartyIdentificationTypeCode "2", causing valid filings to fail validation.

## New Behavior
Validation now requires **at least one** of the accepted TIN types (1, 2, or 4) to be present, matching FinCEN requirements.
