### PR TITLE
fix: nil-safe TotalAmount for empty Activity (fuzz crash)

### DIFF
--- a/pkg/batch/empty_activity_test.go
+++ b/pkg/batch/empty_activity_test.go
@@ -1,0 +1,21 @@
+package batch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for CI fuzz crash FuzzCreateReport/474230c329ae08c9:
+// empty <Activity/> with FormTypeCode CTRX panicked in TotalAmount via Validate.
+func TestValidate_EmptyCTRActivityNoPanic(t *testing.T) {
+	input := []byte(`<EFilingBatchXML><Activity></Activity><FormTypeCode>CTRX</FormTypeCode></EFilingBatchXML>`)
+	report, err := CreateReportWithBuffer(input)
+	require.NoError(t, err)
+	require.NotNil(t, report)
+	require.NotPanics(t, func() {
+		_ = report.Validate()
+		_ = report.GenerateAttrs()
+		_ = report.GenerateSeqNumbers()
+	})
+}

--- a/pkg/cash_payments/activity.go
+++ b/pkg/cash_payments/activity.go
@@ -51,8 +51,11 @@ func (r ActivityType) TotalAmount() float64 {
 	// The sum of all <DetailTransactionAmountText> element amounts
 
 	var amount float64
+	if r.CurrencyTransactionActivity == nil {
+		return amount
+	}
 	for _, currency := range r.CurrencyTransactionActivity.CurrencyTransactionActivityDetail {
-		if currency.DetailTransactionAmountText == nil {
+		if currency == nil || currency.DetailTransactionAmountText == nil {
 			continue
 		}
 

--- a/pkg/cash_payments/total_amount_test.go
+++ b/pkg/cash_payments/total_amount_test.go
@@ -1,0 +1,14 @@
+package cash_payments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTotalAmount_NilCurrencyTransactionActivity(t *testing.T) {
+	act := ActivityType{}
+	require.NotPanics(t, func() {
+		require.Equal(t, 0.0, act.TotalAmount())
+	})
+}

--- a/pkg/currency_transaction/activity.go
+++ b/pkg/currency_transaction/activity.go
@@ -49,7 +49,13 @@ func (r ActivityType) FormTypeCode() string {
 func (r ActivityType) TotalAmount() float64 {
 	// The sum of all amount values recorded for the <DetailTransactionAmountText> element
 	var amount float64
+	if r.CurrencyTransactionActivity == nil {
+		return amount
+	}
 	for _, currency := range r.CurrencyTransactionActivity.CurrencyTransactionActivityDetail {
+		if currency == nil {
+			continue
+		}
 		valueStr := string(currency.DetailTransactionAmountText)
 		if value, err := strconv.ParseFloat(valueStr, 64); err == nil {
 			amount += value

--- a/pkg/currency_transaction/total_amount_test.go
+++ b/pkg/currency_transaction/total_amount_test.go
@@ -1,0 +1,16 @@
+package currency_transaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTotalAmount_NilCurrencyTransactionActivity(t *testing.T) {
+	// Empty Activity unmarshaled from XML leaves CurrencyTransactionActivity nil.
+	// Validate/generateAttrs must not panic when summing amounts.
+	act := ActivityType{}
+	require.NotPanics(t, func() {
+		require.Equal(t, 0.0, act.TotalAmount())
+	})
+}

--- a/pkg/suspicious_activity/activity.go
+++ b/pkg/suspicious_activity/activity.go
@@ -61,7 +61,7 @@ func (r ActivityType) TotalAmount() float64 {
 
 	var amount float64
 
-	if r.SuspiciousActivity.TotalSuspiciousAmountText != nil {
+	if r.SuspiciousActivity != nil && r.SuspiciousActivity.TotalSuspiciousAmountText != nil {
 		valueStr := string(*r.SuspiciousActivity.TotalSuspiciousAmountText)
 		if value, err := strconv.ParseFloat(valueStr, 64); err == nil {
 			amount += value

--- a/pkg/suspicious_activity/total_amount_test.go
+++ b/pkg/suspicious_activity/total_amount_test.go
@@ -1,0 +1,14 @@
+package suspicious_activity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTotalAmount_NilSuspiciousActivity(t *testing.T) {
+	act := ActivityType{}
+	require.NotPanics(t, func() {
+		require.Equal(t, 0.0, act.TotalAmount())
+	})
+}

--- a/test/fuzz/testdata/fuzz/FuzzCreateReport/474230c329ae08c9
+++ b/test/fuzz/testdata/fuzz/FuzzCreateReport/474230c329ae08c9
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("<EFilingBatchXML><Activity></Activity><FormTypeCode>CTRX</FormTypeCode></EFilingBatchXML>")


### PR DESCRIPTION
## Summary
CI fuzz run of `FuzzCreateReport` panicked on:

```xml
<EFilingBatchXML><Activity></Activity><FormTypeCode>CTRX</FormTypeCode></EFilingBatchXML>
```

Stack: `currency_transaction.ActivityType.TotalAmount` → nil `CurrencyTransactionActivity` while `batch.generateAttrs` / `Validate` summed activity amounts.

## Fix
- Nil-check `CurrencyTransactionActivity` (CTR + Form 8300) and detail entries before summing
- Nil-check `SuspiciousActivity` for SAR amounts
- Regression tests + seed corpus `FuzzCreateReport/474230c329ae08c9`

## Test plan
- [x] `go test ./pkg/batch/ ./pkg/currency_transaction/ ./pkg/cash_payments/ ./pkg/suspicious_activity/`
- [x] `go test ./test/fuzz/ -run=FuzzCreateReport/474230c329ae08c9`
- [ ] CI fuzz workflow re-run after merge

Found by: https://github.com/moov-io/fincen/actions/runs/31212954382