### PR TITLE
ci: skip code owners on GitHub Actions workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,7 @@ go.mod
 go.sum
 **/go.mod
 **/go.sum
+
+# GitHub Actions workflows have no owners so action-only PRs skip code-owner review.
+.github/workflows/*
+**/.github/workflows/*


### PR DESCRIPTION
Leave the catch-all CODEOWNERS in place, but give workflow files no owners so action-only PRs (for example Renovate `github/codeql-action` pin bumps) do not require a code-owner review.

This is the same pattern as #122 for `go.mod`/`go.sum`. Once this is on `master`, https://github.com/moov-io/fincen/pull/125 can auto-merge after checks pass.